### PR TITLE
:wrench:fix: youtube 영상 embedabble 확인 기능 추가

### DIFF
--- a/server/nodejs/source/app/controller/youtube/api.js
+++ b/server/nodejs/source/app/controller/youtube/api.js
@@ -52,16 +52,13 @@ const youtubeAPIsearch = async (req, res) => {
       id: music_url,
       maxResults: 1,
     });
-    console.log('videoInfo : ', videoInfo);
-    console.log('videoInfo.data.items : ', videoInfo.data.items);
 
     let { duration } = videoInfo.data.items[0].contentDetails;
-    duration = durationSecoend(duration);
     const { title } = videoInfo.data.items[0].snippet;
     const thumbnailUrl = thumbnailFindImg(
       videoInfo.data.items[0].snippet.thumbnails
     );
-    console.log('thumbnailUrl : ', thumbnailUrl);
+    duration = durationSecoend(duration);
     const { embeddable } = videoInfo.data.items[0].status;
     return { title, thumbnailUrl, duration, embeddable };
   }
@@ -87,7 +84,8 @@ const youtubeAPIsearch = async (req, res) => {
       const { music_name: title, music_length: duration } =
         musicFindOne.dataValues;
       const thumbnailUrl = `https://final.eax.kr/images/${music_url}.jpg`;
-      return { duration, title, thumbnailUrl };
+      const embeddable = true;
+      return { duration, title, thumbnailUrl, embeddable };
     })
     .then((videoInfo) => {
       const { duration, title, thumbnailUrl, embeddable } = videoInfo;


### PR DESCRIPTION
youtube 영상 중 embedabble 이 false 일 경우 다른 웹 사이트에서 작동을 하지 않습니다.
그렇기에 false 인 값을 받을 경우 따로 DB 에 저장 하지 않은 상태에서 415번 에러를 반환 하도록 작성 했습니다.
비회원 일 경우는 db에 저장되지 않은 노래이니 반드시 youtube API 를 거치게 되며, embedabble 값을 반환하게 됩니다.
노래가 있는 경우는 embedabble 값이 true 인 값만 저장을 하니 따로 반환 해주지 않습니다.