### PR TITLE
:bug:bug: 패스워드 초기화 인증 메일 불필요 검사로 인한 메일 전송 에러 수정

### DIFF
--- a/server/nodejs/source/app/controller/utils/passwords.js
+++ b/server/nodejs/source/app/controller/utils/passwords.js
@@ -16,8 +16,6 @@ const sendEmailToRetrievePassword = async (req, res) => {
   var path = `/api/passwords POST`;
   const stub = `sendEmailToRetrievePassword`;
   console.log(`[stub] ${path} ${stub}`);
-  const tokenCheck = checkToken_400_401_404(res, path, req.token);
-  if (!tokenCheck) return;
   checkInputData(res, [req.body['email']]);
   const { email } = req.body;
 


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix/none-메일인증-token에러핸들링 -> main

### 변경 사항
token 을 받지 않음에도 token을 확인 하고 있었습니다. 이를 수정 했습니다.